### PR TITLE
Hardcode feauture activation

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -207,9 +207,17 @@ function get_elasticpress_indexable_post_types( array $types ) : array {
  * @return void
  */
 function override_elasticpress_feature_activation( bool $is_active, array $settings, EP_Feature $feature ) {
-	if ( $feature->slug !== 'documents' ) {
+	$config = get_config()['modules']['search'];
+	$features_activated = [
+		'search'        => true,
+		'related_posts' => false,
+		'documents'     => $config['index-documents'],
+		'facets'        => false,
+	];
+
+	if ( ! isset( $features_activated[ $feature->slug ] ) ) {
 		return $is_active;
 	}
 
-	return get_config()['modules']['search']['index-documents'];
+	return $features_activated[ $feature->slug ];
 }


### PR DESCRIPTION
Turns out EP activates all features that have satisfied requirements, therefore after an index, you get facets, search and related_posts enabled. We only want to use search for now, so let's just stick to that.